### PR TITLE
rtph264depay: fix an error when the total number of SPS was 32

### DIFF
--- a/gst/rtp/gstrtph264depay.c
+++ b/gst/rtp/gstrtph264depay.c
@@ -328,8 +328,8 @@ gst_rtp_h264_set_src_caps (GstRtpH264Depay * rtph264depay)
 
     /* 6 bits reserved | 2 bits lengthSizeMinusOn */
     *data++ = 0xff;
-    /* 3 bits reserved | 5 bits numOfSequenceParameterSets */
-    *data++ = 0xe0 | (rtph264depay->sps->len & 0x1f);
+    /* We guarantee that rtph264depay->sps->len <= 32 */
+    *data++ = (guint8) rtph264depay->sps->len;
 
     /* copy all SPS */
     for (i = 0; i < rtph264depay->sps->len; i++) {
@@ -514,6 +514,10 @@ gst_rtp_h264_add_sps_pps (GstElement * rtph264, GPtrArray * sps_array,
     if (!parse_sps (&map, &sps_id)) {
       GST_WARNING_OBJECT (rtph264, "Invalid SPS,"
           " can't parse seq_parameter_set_id");
+      goto drop;
+    }
+    if (G_UNLIKELY (sps_id > 31)) {
+      GST_WARNING_OBJECT (rtph264, "Invalid SPS id ", sps_id);
       goto drop;
     }
 


### PR DESCRIPTION
The mask 0x1f would filter out any number greater than 31.
So in the codec data, we would write 0 as the number of SPS's when the 32nd SPS (with id 31) arrived.
Here we make sure that the array is no longer than 32, so we can write
in the codec_data the total number of SPS without any mask.